### PR TITLE
Fix: Improve sales update logic and add lineup check to workflow

### DIFF
--- a/.github/workflows/aggiornamento_principale.yml
+++ b/.github/workflows/aggiornamento_principale.yml
@@ -54,6 +54,15 @@ jobs:
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         run: python gestionale.py update_sales
 
+      - name: "PASSO 4: Verifica Formazioni Schierate"
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          SORARE_API_KEY: ${{ secrets.SORARE_API_KEY }}
+          GSPREAD_CREDENTIALS: ${{ secrets.GSPREAD_CREDENTIALS }}
+          SPREADSHEET_ID: ${{ secrets.SPREADSHEET_ID }}
+          USER_SLUG: ${{ secrets.USER_SLUG }}
+        run: python check_lineups.py
+
       - name: Salva lo stato (se modificato)
         run: |
           git config --global user.name 'github-actions[bot]'


### PR DESCRIPTION
This commit introduces two main improvements:

1.  The `update_sales` function in `gestionale.py` has been refactored to prevent 'grid limits' errors. It now separates updates for existing rows from additions of new rows, using the robust `append_rows` method for all new entries.
2.  The main GitHub workflow (`aggiornamento_principale.yml`) has been updated to include the execution of the `check_lineups.py` script as its final step.