### PR TITLE
Fix: Correct the syntax for batched GraphQL queries.

### DIFF
--- a/gestionale.py
+++ b/gestionale.py
@@ -50,10 +50,11 @@ PLAYER_TOKEN_PRICES_QUERY = """
 PRICE_FRAGMENT = "liveSingleSaleOffer { receiverSide { amounts { eurCents, usdCents, gbpCents, wei, referenceCurrency } } }"
 def build_batched_card_details_query(card_slugs: list[str]) -> str:
     """
-    Costruisce una query GraphQL per recuperare i dettagli di più carte in una sola volta usando gli alias.
+    Costruisce una query GraphQL per recuperare i dettagli di più carte in una sola volta
+    usando un frammento nominato per evitare errori di duplicazione.
     """
-    card_fields_fragment = f"""
-... on Card {{
+    card_fragment = f"""
+fragment CardDetails on Card {{
     rarity, grade, xp, xpNeededForNextGrade, pictureUrl, inSeasonEligible, secondaryMarketFeeEnabled
     liveSingleSaleOffer {{ receiverSide {{ amounts {{ eurCents, usdCents, gbpCents, wei, referenceCurrency }} }} }}
     player {{
@@ -77,10 +78,10 @@ def build_batched_card_details_query(card_slugs: list[str]) -> str:
         alias = f"card{i}"
         query_body += f'''
     {alias}: anyCard(slug: "{slug}") {{
-        {card_fields_fragment}
+        ...CardDetails
     }}
 '''
-    return f"query GetBatchedCardDetails {{ {query_body} }}"
+    return f"query GetBatchedCardDetails {{ {query_body} }} {card_fragment}"
 PROJECTION_QUERY = """
     query GetProjection($playerSlug: String!, $gameId: ID!) {
         football {


### PR DESCRIPTION
The previous implementation of the batched query for card details was causing a 'Duplicated root field' error from the Sorare API.

This commit refactors the `build_batched_card_details_query` function to use a formal, named GraphQL fragment (`...CardDetails`). The main query body now references this fragment for each aliased `anyCard` field. This is the correct, idiomatic way to structure this query and resolves the API error.