### PR TITLE
Fix(charts): Correct JSON payload for chart creation (styleOverrides)

### DIFF
--- a/gestionale.py
+++ b/gestionale.py
@@ -634,9 +634,9 @@ def create_so5_charts():
                                     'startRowIndex': current_row, 'endRowIndex': current_row + len(reversed_scores),
                                     'startColumnIndex': 1, 'endColumnIndex': 2
                                 }]}},
-                                'colorStyle': {
-                                    'colors': colors
-                                }
+                                'styleOverrides': [
+                                    {'index': i, 'color': color} for i, color in enumerate(colors)
+                                ]
                             }],
                             'axis': [
                                 {'position': 'BOTTOM_AXIS', 'title': 'Partite (la più recente a destra)'},


### PR DESCRIPTION
This commit fixes a `gspread.exceptions.APIError: [400]` caused by an invalid JSON payload for the `addChart` request. This is the final correction after previous attempts.

The `colorStyle` field was still incorrect. The proper way to color individual bars in a series is to use the `styleOverrides` field.

This change replaces the `colorStyle` object with a `styleOverrides` list, where each element specifies the index and color for a data point in the series. This aligns the request with the correct Google Sheets API v4 specification and should resolve the runtime error.