### PR TITLE
Fix(charts): Use correct gspread method names

### DIFF
--- a/gestionale.py
+++ b/gestionale.py
@@ -611,7 +611,7 @@ def create_so5_charts():
         print(f"Foglio '{CHART_SHEET_NAME}' creato.")
 
     chart_sheet.clear()
-    chart_sheet.update('A1:B1', [['Giocatore', 'Grafico Ultimi 5 Punteggi SO5']])
+    chart_sheet.update(range_name='A1:B1', values=[['Giocatore', 'Grafico Ultimi 5 Punteggi SO5']])
     chart_sheet.format('A1:B1', {'textFormat': {'bold': True}})
     print("Foglio dei grafici pulito e intestazioni scritte.")
 
@@ -656,7 +656,7 @@ def create_so5_charts():
         chart_sheet.batch_update(update_data, value_input_option='USER_ENTERED')
 
     # Adjust column and row sizes
-    chart_sheet.set_frozen(rows=1)
+    chart_sheet.freeze(rows=1)
     chart_sheet.update_acell('C1', "Nota: I grafici sono immagini generate da QuickChart.io")
     spreadsheet.batch_update({
         "requests": [


### PR DESCRIPTION
This commit fixes an `AttributeError` and a `DeprecationWarning` related to incorrect `gspread` method calls in the `create_so5_charts` function.

- Replaced the deprecated `worksheet.update(range, values)` with the modern, named-argument version `worksheet.update(range_name=range, values=values)`.
- Replaced the incorrect `worksheet.set_frozen(rows=1)` with the correct method `worksheet.freeze(rows=1)`.

These changes should resolve the final runtime errors and allow the chart generation script to complete successfully.