### PR TITLE
Fix(projections): Revert to original gameId logic and keep enhanced l…

### DIFF
--- a/gestionale.py
+++ b/gestionale.py
@@ -62,7 +62,6 @@ OPTIMIZED_CARD_DETAILS_QUERY = f"""
                 liveSingleSaleOffer {{ receiverSide {{ amounts {{ eurCents, usdCents, gbpCents, wei, referenceCurrency }} }} }}
                 player {{
                     slug, displayName, position, lastFiveSo5Appearances, lastFifteenSo5Appearances
-                    nextSo5Fixture {{ game {{ id }} }}
                     playerGameScores(last: 15) {{ score }}
                     activeInjuries {{ status, expectedEndDate }}
                     activeSuspensions {{ reason, endDate }}
@@ -464,10 +463,11 @@ def update_cards():
         player_info = card_details.get("player")
         player_slug = player_info.get("slug") if player_info else None
 
-        # Get game_id from the more reliable nextSo5Fixture
-        game_id = None
-        if player_info and player_info.get("nextSo5Fixture"):
-            game_id = player_info["nextSo5Fixture"].get("game", {}).get("id")
+        # Get game_id from the club's upcoming games
+        upcoming_games = []
+        if player_info and player_info.get("activeClub"):
+            upcoming_games = player_info.get("activeClub", {}).get("upcomingGames", [])
+        game_id = upcoming_games[0].get("id") if upcoming_games else None
 
         projection_data = fetch_projection(player_slug, game_id)
         updated_row = build_updated_card_row(card_to_update, card_details, player_info, projection_data, rates)


### PR DESCRIPTION
…ogging

After diagnosing a `Field 'nextSo5Fixture' doesn't exist` error from the API, this commit reverts the projection logic to its original, more reliable state while keeping the enhanced error logging.

- The `OPTIMIZED_CARD_DETAILS_QUERY` no longer requests the non-existent `nextSo5Fixture` field.
- The `update_cards` function is restored to use the `activeClub.upcomingGames` field to find the next game ID.
- The enhanced error logging in `sorare_graphql_fetch` is retained. This ensures that when a 422 error occurs (because projection data is not yet available for a game), it is logged as an informative, non-fatal warning, and the script continues.

This represents the most robust and correct implementation based on the behavior of the Sorare API.